### PR TITLE
Correct repository name in releases link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A native Android TV client for [Audiobookshelf](https://www.audiobookshelf.org/)
 ## Installation
 
 ### From Release
-1. Download the latest APK from the [Releases](https://github.com/michaeldvinci/swiftshelf-android/releases) page
+1. Download the latest APK from the [Releases](https://github.com/michaeldvinci/swiftshelf-androidtv/releases) page
 2. Install via ADB: `adb install swiftshelf-<version>.apk`
 3. Or sideload using your preferred method
 


### PR DESCRIPTION
The link in the `README.md` file is missing `tv` from the repository name, causing it to lead to a 404 page.